### PR TITLE
fix: handle empty DataFrames gracefully in daily scrape

### DIFF
--- a/src/linkedin_web_scraper/application/daily_scrape_service.py
+++ b/src/linkedin_web_scraper/application/daily_scrape_service.py
@@ -116,6 +116,17 @@ class DailyScrapeService:
             combined_jobs = pd.concat(scraper_results, ignore_index=True)
             self.storage.store_jobs(run_id, combined_jobs)
             persisted_jobs = self.storage.load_run_jobs(run_id)
+
+            if persisted_jobs.empty:
+                self.logger.warning("No jobs found for %s in %s.", position, location)
+                self.storage.finish_run(
+                    run_id,
+                    status="completed",
+                    output_path=target_output_path,
+                    row_count=0,
+                )
+                return persisted_jobs
+
             file_manager.save_jobs_to_csv(
                 df=persisted_jobs,
                 file_name=target_output_path,

--- a/src/linkedin_web_scraper/infra/storage/file_manager.py
+++ b/src/linkedin_web_scraper/infra/storage/file_manager.py
@@ -38,6 +38,10 @@ class FileManager:
         append: bool = True,
     ) -> None:
         """Save or append jobs to a CSV file."""
+        if df.empty:
+            self.logger.warning("Skipping CSV save: no jobs to persist.")
+            return
+
         target_file = resolve_jobs_output_path(
             file_name or self.generate_file_name(), self.output_dir
         )


### PR DESCRIPTION
## Description

Fixes issue #4 where the daily scrape workflow crashes when no jobs are found for the given search criteria.

## Problem

When no jobs are scraped, the system attempted to save an empty DataFrame to CSV, causing:
- \pandas.errors.EmptyDataError: No columns to parse from file\ when appending to existing files
- Exit code 1 instead of graceful cleanup

## Solution

Added empty DataFrame checks in two places:

1. **FileManager.save_jobs_to_csv()**: Skip CSV operations and log warning when DataFrame is empty
2. **DailyScrapeService.run_for_location()**: Detect empty results after loading and finalize run cleanly with row_count=0

## Testing

- All 89 existing tests pass
- Daily scrape smoke tests verified
- Process DS jobs script tests verified
- Example smoke tests verified

Closes #4