### PR TITLE
feat: persist sqlite state as a data-latest release asset

### DIFF
--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -59,13 +59,29 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts/state artifacts/jobs artifacts/logs
-          if gh release view data-latest --json assets --jq '.assets[].name' | grep -qx 'linkedin_jobs.sqlite'; then
+          # A transient API failure must abort the run, never masquerade as "state absent":
+          # a fresh database published with --clobber would destroy the canonical state.
+          if ! releases=$(gh release list --limit 200 --json tagName --jq '.[].tagName'); then
+            echo "::error::Could not list releases; refusing to guess about persisted state."
+            exit 1
+          fi
+          asset_present=false
+          if grep -qx 'data-latest' <<<"$releases"; then
+            if ! assets=$(gh release view data-latest --json assets --jq '.assets[].name'); then
+              echo "::error::Could not list data-latest assets; refusing to guess about persisted state."
+              exit 1
+            fi
+            if grep -qx 'linkedin_jobs.sqlite' <<<"$assets"; then
+              asset_present=true
+            fi
+          fi
+          if [ "$asset_present" = true ]; then
             gh release download data-latest --pattern linkedin_jobs.sqlite --dir artifacts/state
             echo "State restored from the data-latest release."
           elif [ "${{ inputs.allow_fresh_state }}" = "true" ]; then
-            echo "No data-latest release asset found; starting with a fresh state database (allow_fresh_state)."
+            echo "Asset confirmed absent; starting with a fresh state database (allow_fresh_state)."
           else
-            echo "::error::Could not confirm the linkedin_jobs.sqlite asset on the data-latest release. Refusing to start fresh so a transient API failure can never clobber the canonical state. For first-run bootstrap, dispatch with allow_fresh_state=true."
+            echo "::error::The data-latest release asset is absent. Refusing to start fresh; dispatch with allow_fresh_state=true for first-run bootstrap."
             exit 1
           fi
 

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "30 12 * * *"
   workflow_dispatch:
+    inputs:
+      allow_fresh_state:
+        description: "Start with a fresh state database when the data-latest release asset is missing (first-run bootstrap only)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -27,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -49,27 +54,20 @@ jobs:
           fi
 
       - name: Restore persisted state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          import shutil
-
-          for directory in (Path("artifacts/state"), Path("artifacts/jobs"), Path("artifacts/logs")):
-              directory.mkdir(parents=True, exist_ok=True)
-
-          source = Path(".tmp/data-branch/state")
-          target = Path("artifacts/state")
-          if not source.exists():
-              raise SystemExit(0)
-
-          for item in source.iterdir():
-              destination = target / item.name
-              if item.is_dir():
-                  shutil.copytree(item, destination, dirs_exist_ok=True)
-              else:
-                  destination.parent.mkdir(parents=True, exist_ok=True)
-                  shutil.copy2(item, destination)
-          PY
+          mkdir -p artifacts/state artifacts/jobs artifacts/logs
+          if gh release view data-latest --json assets --jq '.assets[].name' | grep -qx 'linkedin_jobs.sqlite'; then
+            gh release download data-latest --pattern linkedin_jobs.sqlite --dir artifacts/state
+            echo "State restored from the data-latest release."
+          elif [ "${{ inputs.allow_fresh_state }}" = "true" ]; then
+            echo "No data-latest release asset found; starting with a fresh state database (allow_fresh_state)."
+          else
+            echo "::error::Could not confirm the linkedin_jobs.sqlite asset on the data-latest release. Refusing to start fresh so a transient API failure can never clobber the canonical state. For first-run bootstrap, dispatch with allow_fresh_state=true."
+            exit 1
+          fi
 
       - name: Initialize SQLite schema
         run: |
@@ -92,7 +90,18 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: linkedin-webscraper scrape daily --config .github/runtime/daily.toml
 
-      - name: Sync state and exports into data branch
+      - name: Publish state to data-latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if ! gh release view data-latest >/dev/null 2>&1; then
+            gh release create data-latest --title "Scraper state (rolling)" --latest=false \
+              --notes "Rolling canonical scraper state. The Daily Scrape workflow restores linkedin_jobs.sqlite from this release and uploads the updated copy after each run."
+          fi
+          gh release upload data-latest artifacts/state/linkedin_jobs.sqlite --clobber
+
+      - name: Sync exports into data branch
         run: |
           python - <<'PY'
           from datetime import datetime, timezone
@@ -101,19 +110,12 @@ jobs:
 
           run_date = datetime.now(timezone.utc).date().isoformat()
           data_root = Path(".tmp/data-branch")
-          state_source = Path("artifacts/state")
           jobs_source = Path("artifacts/jobs")
 
-          state_target = data_root / "state"
           latest_target = data_root / "exports" / "latest"
           dated_target = data_root / "exports" / run_date
 
-          for directory in (state_target, latest_target.parent, dated_target.parent):
-              directory.mkdir(parents=True, exist_ok=True)
-
-          if state_target.exists():
-              shutil.rmtree(state_target)
-          shutil.copytree(state_source, state_target)
+          latest_target.parent.mkdir(parents=True, exist_ok=True)
 
           if latest_target.exists():
               shutil.rmtree(latest_target)
@@ -124,15 +126,15 @@ jobs:
           shutil.copytree(jobs_source, dated_target)
           PY
 
-      - name: Commit and push automation state
+      - name: Commit and push export data
         working-directory: .tmp/data-branch
         shell: bash
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add state exports
+          git add exports
           if git diff --cached --quiet; then
-            echo "No automation state changes to commit."
+            echo "No export changes to commit."
             exit 0
           fi
           git commit -m "Daily scrape $(date -u +%F)"
@@ -140,7 +142,7 @@ jobs:
 
       - name: Upload scrape artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: daily-scrape-${{ github.run_id }}
           path: |
@@ -157,14 +159,14 @@ jobs:
             echo "## Daily scrape"
             echo
             echo "- Workflow config: .github/runtime/daily.toml"
-            echo "- State branch: data"
+            echo "- State: data-latest release asset (exports on the data branch)"
             echo "- Artifact retention: 14 days"
             echo "- Trigger: ${{ github.event_name }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Close open automation failure issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = "[automation] Daily scrape failure";
@@ -191,7 +193,7 @@ jobs:
 
       - name: Open or update automation failure issue
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = "[automation] Daily scrape failure";

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -100,13 +100,13 @@ The workflow sequence is:
 
 1. install the package with the optional OpenAI extra available
 2. attach a `data` branch worktree
-3. restore the previous SQLite state from `data/state`
+3. restore the previous SQLite state from the `data-latest` release asset; a run refuses to start fresh unless it positively confirms the asset is absent and was dispatched with `allow_fresh_state=true` (first-run bootstrap only)
 4. initialize the SQLite schema before the scrape
 5. run a CLI dry run for visibility
 6. run `linkedin-webscraper scrape daily --config .github/runtime/daily.toml`
-7. copy `artifacts/state` back to `data/state`
+7. upload `artifacts/state/linkedin_jobs.sqlite` back to the `data-latest` release with `--clobber`
 8. copy current CSV exports to both `data/exports/latest` and `data/exports/YYYY-MM-DD`
-9. commit and push the updated automation state back to `data`
+9. commit and push the export data back to `data`
 10. upload workflow artifacts and summarize the run
 
 ### Failure Handling
@@ -122,5 +122,6 @@ The workflow includes:
 
 - Keep secrets out of TOML and out of the repo.
 - If you enable OpenAI for scheduled runs later, do it by combining a repo secret with `openai_enabled = true` in `.github/runtime/daily.toml` or a workflow env override.
-- The `data` branch is the current persistence contract for GitHub-hosted automation. A future cloud database can replace it without changing the CLI surface.
+- The persistence contract for GitHub-hosted automation: the canonical `linkedin_jobs.sqlite` lives as an asset on the rolling `data-latest` release (2 GiB per-file limit, kept out of git history); CSV exports live on the `data` branch. A future cloud database can replace the release asset without changing the CLI surface.
+- Rollback for state: every run also uploads `artifacts/state` as a workflow artifact with 14-day retention; re-upload a prior day's database to the `data-latest` release to roll back.
 - Use `python -m tox -e preflight` before risky pushes or merges. That local gate runs the same smoke, lint, type, docs, and build checks that the repo expects before release work.

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -72,13 +72,21 @@ def test_release_workflow_uses_auto_release_and_trusted_publishing() -> None:
     assert "testpypi" not in text
 
 
-def test_daily_workflow_persists_state_branch_and_artifacts() -> None:
+def test_daily_workflow_persists_release_state_and_artifacts() -> None:
     text = _read(".github/workflows/daily-scrape.yml")
     assert "schedule:" in text
-    assert "data" in text
     assert "git worktree add --orphan -b data .tmp/data-branch" in text
     assert ".github/runtime/daily.toml" in text
-    assert "actions/upload-artifact@v4" in text
+    assert "gh release download data-latest" in text
+    assert "gh release upload data-latest artifacts/state/linkedin_jobs.sqlite --clobber" in text
+    # a scheduled run must never fresh-start; only an explicit dispatch input may
+    assert "allow_fresh_state" in text
+    assert "Refusing to start fresh" in text
+    assert "git add exports" in text
+    assert "git add state" not in text
+    assert "actions/setup-python@v7" in text
+    assert "actions/upload-artifact@v7" in text
+    assert "actions/github-script@v9" in text
     assert "[automation] Daily scrape failure" in text
 
 


### PR DESCRIPTION
## Summary
- Daily Scrape persists linkedin_jobs.sqlite as an asset on the rolling data-latest release (2 GiB per-file limit) instead of committing it to the data branch, whose push has been rejected since 2026-07-28 (file crossed GitHub's hard 100 MiB limit).
- Restore step downloads the asset at run start; publish step uploads it with --clobber after the scrape. CSV exports still commit to the data branch, unchanged.
- Data-loss guard (added after adversarial review): scheduled runs refuse to fresh-start when the asset cannot be confirmed, so a transient API failure or an interrupted clobber can never silently overwrite the canonical state. First-run bootstrap (forks) requires dispatching with allow_fresh_state=true.
- Deprecated Node 20 actions bumped: setup-python v5 to v7, upload-artifact v4 to v7, github-script v7 to v9 (input usage verified compatible).
- tests/test_github_workflows.py pins the new contract: release download/upload commands, the fresh-start refusal, exports-only staging, and the new action versions.

## Verification
- tox -e py312: 89 passed; tox -e lint: green; workflow YAML parsed, 15-step graph confirmed.
- Adversarial review pass done pre-PR; both confirmed findings (silent fresh-start on transient release-view failure; clobber delete-then-upload escalating to loss one run later) are closed by the refusal guard.
- data-latest release is already seeded with the recovery DB from #7 (102.68 MiB, per-table counts on the issue).

## Post-merge
1. Dispatch the workflow twice (no inputs); the second run proves the download-modify-upload roundtrip and should auto-close the open failure issue.
2. One-off op executed directly after merge (tracked on the issue): delete state/ from the data branch tip so consumer checkouts shrink to CSVs only. Until ricardogr07/mx-jobs-insights#5 lands, the consumer's auto mode falls back to fresh CSVs.

Rollback: every run still uploads artifacts/state as a 14-day workflow artifact; re-upload any prior day's DB to the release to roll back.

Closes ricardogr07/LinkedInWebScraper#11
